### PR TITLE
Ajout affichage humidité cible

### DIFF
--- a/enceinte_fil3d.yaml
+++ b/enceinte_fil3d.yaml
@@ -281,9 +281,6 @@ display:
         it.print(0, 39, id(my_font), buffer);
       }
 
-      snprintf(buffer, sizeof(buffer), "T Cible: %.0f C", id(temperature_cible).state);
-      it.print(0, 52, id(my_font), buffer);
-
       float pwm_pct = 0.0f;
       bool chauffe_on = false;
       if (id(mode_fonctionnement).state == "Test") {
@@ -293,16 +290,27 @@ display:
         pwm_pct = id(chauffage_dimmable).current_values.get_brightness() * 100.0f;
         chauffe_on = (pwm_pct > 0.0f);
       }
+
       if (id(mode_fonctionnement).state == "Off") {
         snprintf(buffer, sizeof(buffer), "Matériel: %s", id(filament).state.c_str());
-        it.print(0, 64, id(my_font), buffer);
-      } else if (id(mode_fonctionnement).state == "Maintien" || id(mode_fonctionnement).state == "Séchage approfondi") {
+        it.print(0, 52, id(my_font), buffer);
+      } else {
         snprintf(buffer, sizeof(buffer), "Chauffage %s: %s %.0f%%", id(filament).state.c_str(), chauffe_on ? "ON" : "OFF", pwm_pct);
-        it.print(0, 64, id(my_font), buffer);
-      } else if (id(mode_fonctionnement).state == "Test") {
-        snprintf(buffer, sizeof(buffer), "Chauffage %s: %s %.0f%%", id(filament).state.c_str(), chauffe_on ? "ON" : "OFF", pwm_pct);
-        it.print(0, 64, id(my_font), buffer);
+        it.print(0, 52, id(my_font), buffer);
       }
+
+      float humidite_cible_aff = NAN;
+      if (id(mode_fonctionnement).state == "Maintien") {
+        humidite_cible_aff = id(humidite_cible_maintien).state;
+      } else if (id(mode_fonctionnement).state == "Séchage approfondi") {
+        humidite_cible_aff = id(humidite_cible_sechage).state;
+      }
+      if (isnan(humidite_cible_aff)) {
+        snprintf(buffer, sizeof(buffer), "T %.0fC", id(temperature_cible).state);
+      } else {
+        snprintf(buffer, sizeof(buffer), "T %.0fC H %.0f%%", id(temperature_cible).state, humidite_cible_aff);
+      }
+      it.print(0, 64, id(my_font), buffer);
     update_interval: 2s
 
 binary_sensor:
@@ -349,8 +357,12 @@ binary_sensor:
                 ESP_LOGI("bouton_plus", "Filament changé: %s, Température cible: %.1f°C", it->c_str(), temp_cible_filament);
               }
             } else {
-              // En mode Maintien ou Séchage, bouton + incrémente humidite_cible_maintien max 50%
-              id(humidite_cible_maintien).publish_state(std::min(id(humidite_cible_maintien).state + 1, 50.0f));
+              // En mode Maintien ou Séchage, bouton + ajuste l'humidité cible correspondante (max 50%)
+              if (id(mode_fonctionnement).state == "Maintien") {
+                id(humidite_cible_maintien).publish_state(std::min(id(humidite_cible_maintien).state + 1, 50.0f));
+              } else {
+                id(humidite_cible_sechage).publish_state(std::min(id(humidite_cible_sechage).state + 1, 50.0f));
+              }
             }
         - script.execute: gestion_chauffage
         - lambda: |-
@@ -402,8 +414,12 @@ binary_sensor:
                 ESP_LOGI("bouton_moins", "Filament changé: %s, Température cible: %.1f°C", it->c_str(), temp_cible_filament);
               }
             } else {
-              // En mode Maintien ou Séchage, bouton - décrémente humidite_cible_maintien min 10%
-              id(humidite_cible_maintien).publish_state(std::max(id(humidite_cible_maintien).state - 1, 10.0f));
+              // En mode Maintien ou Séchage, bouton - ajuste l'humidité cible correspondante (min 10%)
+              if (id(mode_fonctionnement).state == "Maintien") {
+                id(humidite_cible_maintien).publish_state(std::max(id(humidite_cible_maintien).state - 1, 10.0f));
+              } else {
+                id(humidite_cible_sechage).publish_state(std::max(id(humidite_cible_sechage).state - 1, 10.0f));
+              }
             }
         - script.execute: gestion_chauffage
         - lambda: |-


### PR DESCRIPTION
## Summary
- afficher l'humidité cible en plus de la température
- ajuster l'humidité avec les boutons + et - selon le mode

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686196e877ec833098fcc60c5ccaf813