### PR TITLE
Clarify local ESPHome run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ Si Home Assistant n'arrive pas à compiler le projet (fichier trop volumineux ou
    esphome run /chemin/vers/Enceinte_fil3D/install.yaml
    ```
 
+   > ℹ️ **Astuce :** si vous préférez utiliser un chemin relatif, placez-vous d'abord dans le dossier du projet :
+   > ```bash
+   > cd /chemin/vers/Enceinte_fil3D
+   > esphome run install.yaml
+   > ```
+   > Sinon, assurez-vous de fournir le **chemin complet** vers `install.yaml` lorsque vous lancez la commande depuis un autre emplacement.
+
 > 💡 Lors de la première exécution, ESPHome vous proposera de flasher l'ESP32 connecté en USB. Les compilations suivantes pourront être envoyées via le réseau.
 
 ---


### PR DESCRIPTION
## Summary
- document how to launch `esphome run` from the project directory when using a relative path
- remind readers to use the full path to `install.yaml` if running the command elsewhere

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905d4b1eaf08330bb546292e4e29411