### PR TITLE
Document Wi-Fi secrets configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ wifi:
 
 ---
 
+### 🔐 Configuration du Wi-Fi via `secrets.yaml`
+
+Pour que l'ESP32 se connecte correctement à votre réseau, les identifiants Wi-Fi doivent être définis dans un fichier de secrets :
+
+1. **Depuis Home Assistant / ESPHome** :
+   - Ouvrez l'interface ESPHome et cliquez sur le menu "Secrets" (icône 🔑 en bas à gauche).
+   - Ajoutez les entrées suivantes en remplaçant par vos informations :
+     ```yaml
+     wifi_ssid: "NomDeVotreReseau"
+     wifi_password: "MotDePasseSuperSecret"
+     ```
+2. **En compilation locale** : créez (ou complétez) le fichier `secrets.yaml` dans le même dossier que `install.yaml` avec les mêmes clés `wifi_ssid` et `wifi_password`.
+
+⚠️ Sans ces secrets, l'appareil ne pourra pas se connecter au Wi-Fi et la compilation ESPHome échouera. Assurez-vous également que `install.yaml` référence bien ces clés (voir fichier pour les commentaires détaillés).
+
+---
+
 ### 💻 Compilation locale depuis un terminal macOS
 
 Si Home Assistant n'arrive pas à compiler le projet (fichier trop volumineux ou mémoire insuffisante), il est possible de **générer le firmware directement depuis un Mac** en utilisant le terminal.

--- a/install.yaml
+++ b/install.yaml
@@ -21,5 +21,5 @@ api:  # Active l’API ESPHome pour la communication avec Home Assistant.
     key: tsHqLo48mLGhWo/qQQrZUFdsEwuZcC1/BlUOXWExy14=  # Clé de chiffrement pour sécuriser les échanges.
 
 wifi:  # Configuration du réseau Wi-Fi pour connecter l’ESP32.
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
+  ssid: !secret wifi_ssid  # Renseignez ces valeurs dans votre fichier secrets.yaml.
+  password: !secret wifi_password  # Voir le README pour les instructions de création.


### PR DESCRIPTION
## Summary
- document how to provide Wi-Fi credentials via secrets.yaml for ESPHome deployments
- annotate install.yaml Wi-Fi section with pointers to the secrets documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905d7aa304883308ec9bdca4fdb39bb