### PR TITLE
Expose drying countdown sensor to Home Assistant

### DIFF
--- a/enceinte_fil3d.yaml
+++ b/enceinte_fil3d.yaml
@@ -73,6 +73,15 @@ sensor:
           - logger.log: "Mise à jour forcée après lecture humidité DHT."
     update_interval: 10s
 
+  - platform: template
+    name: "Temps restant Séchage"
+    id: temps_restant_sechage_sensor
+    unit_of_measurement: "min"
+    accuracy_decimals: 0
+    icon: "mdi:clock-outline"
+    lambda: 'return (float) id(temps_restant_sechage);'
+    update_interval: never
+
 output:
   - platform: ledc
     pin: 14  # Contrôle du MOSFET en PWM
@@ -153,6 +162,7 @@ select:
             else:
               - lambda: |-
                   id(temps_restant_sechage) = 0;
+                  id(temps_restant_sechage_sensor).publish_state(0);
 
   - platform: template
     name: "Filament"
@@ -274,6 +284,7 @@ script:
     then:
       - lambda: |-
           id(temps_restant_sechage) = (int)(id(duree_sechage).state * 60);
+          id(temps_restant_sechage_sensor).publish_state(id(temps_restant_sechage));
       - while:
           condition:
             lambda: 'return id(temps_restant_sechage) > 0 && id(mode_fonctionnement).state == "Séchage approfondi";'
@@ -281,12 +292,15 @@ script:
             - delay: 60s
             - lambda: |-
                 id(temps_restant_sechage) -= 1;
+                id(temps_restant_sechage_sensor).publish_state(id(temps_restant_sechage));
                 ESP_LOGD("timer_sechage", "Temps restant %d min", id(temps_restant_sechage));
                 if (id(ecran_oled) != nullptr) { id(ecran_oled).update(); }
       - lambda: |-
           if (id(mode_fonctionnement).state == "Séchage approfondi") {
             id(mode_fonctionnement).publish_state("Maintien");
           }
+          id(temps_restant_sechage) = 0;
+          id(temps_restant_sechage_sensor).publish_state(0);
 
 font:
   - file: "gfonts://Roboto"


### PR DESCRIPTION
## Summary
- add a template sensor that mirrors the drying countdown global for Home Assistant
- publish countdown updates whenever the drying timer starts, ticks, or ends

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_6905fa5ca3988330aaa62c47d05629cb