### PR TITLE
Refine drying countdown exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Cette enceinte de stockage pour **filaments 3D** permet de **maintenir une faibl
 - **Mode séchage approfondi** : Assèche intensément les filaments et le dessicant.
 - **Régulation intelligente de la chauffe** (PWM progressif selon l'humidité).
 - **Affichage OLED avec veille automatique** après 10 minutes d’inactivité.
+- **Temps de séchage restant visible dans Home Assistant** via un capteur dédié.
 - **Réglage de la durée du séchage approfondi** (1 à 8 heures).
 - **Contrôle via boutons physiques et Home Assistant**.
 - **Sélection du type de filament directement via les boutons physiques en mode Off ou Maintien/Séchage**
@@ -49,7 +50,8 @@ Cette enceinte de stockage pour **filaments 3D** permet de **maintenir une faibl
 - **ABS** : 65-75°C (4 heures)
 - **Nylon** : 70-80°C (4 heures)
 
-💡 **La durée est réglable de 1h à 8h via Home Assistant**.  
+💡 **La durée est réglable de 1h à 8h via Home Assistant**.
+⌛ **Un capteur `Temps restant Séchage` expose le compte à rebours en minutes dans Home Assistant** pour suivre l'avancement depuis l'interface ou des automatisations.
 ⌛ **Une fois terminé, l’enceinte repasse automatiquement en mode Maintien**.
 
 ---
@@ -259,7 +261,12 @@ cards:
       - type: template
         icon: mdi:timer-sand
         content: >
-          {{ states('sensor.enceintefil3d_humidite') }}% · {{ states('sensor.enceintefil3d_temperature') }}°C
+          {% set reste = states('sensor.enceintefil3d_temps_restant_sechage') | int(0) %}
+          {% if reste > 0 %}
+            {{ reste }} min restants
+          {% else %}
+            Séchage en veille
+          {% endif %}
       - type: entity
         entity: light.enceintefil3d_chauffage_progressif
         name: Chauffage
@@ -313,6 +320,15 @@ cards:
           - condition: state
             entity: select.enceintefil3d_mode_de_fonctionnement
             state: 'Séchage approfondi'
+      - type: custom:mushroom-entity-card
+        entity: sensor.enceintefil3d_temps_restant_sechage
+        name: Temps restant
+        icon: mdi:timer-sand
+        layout: vertical
+        visibility:
+          - condition: state_not
+            entity: sensor.enceintefil3d_temps_restant_sechage
+            state_not: '0'
       - type: custom:mushroom-number-card
         entity: number.enceintefil3d_puissance_test
         name: PWM test
@@ -335,7 +351,7 @@ cards:
         layout: vertical
 ```
 
-Les blocs `visibility` n’affichent que les réglages pertinents selon le mode actif (Maintien, Séchage approfondi ou Test) pour conserver une interface claire et compacte.
+Les blocs `visibility` n’affichent que les réglages pertinents selon le mode actif (Maintien, Séchage approfondi ou Test) pour conserver une interface claire et compacte, tandis que la pastille et la carte "Temps restant" se mettent automatiquement à jour pendant un cycle de séchage.
 
 ---
 

--- a/enceinte_fil3d.yaml
+++ b/enceinte_fil3d.yaml
@@ -12,6 +12,10 @@ esphome:
           } else {
             ESP_LOGW("boot", "OLED non initialisé lors du boot, update ignoré");
           }
+      - lambda: |-
+          if (id(temps_restant_sechage_sensor) != nullptr) {
+            id(temps_restant_sechage_sensor).publish_state(id(temps_restant_sechage));
+          }
 
 esp32:
   board: esp32dev
@@ -72,6 +76,16 @@ sensor:
               }
           - logger.log: "Mise à jour forcée après lecture humidité DHT."
     update_interval: 10s
+
+  - platform: template
+    name: "Temps restant Séchage"
+    id: temps_restant_sechage_sensor
+    unit_of_measurement: "min"
+    accuracy_decimals: 0
+    device_class: duration
+    icon: "mdi:clock-outline"
+    lambda: 'return (float) id(temps_restant_sechage);'
+    update_interval: never
 
 output:
   - platform: ledc
@@ -153,6 +167,7 @@ select:
             else:
               - lambda: |-
                   id(temps_restant_sechage) = 0;
+                  id(temps_restant_sechage_sensor).publish_state(0);
 
   - platform: template
     name: "Filament"
@@ -274,6 +289,7 @@ script:
     then:
       - lambda: |-
           id(temps_restant_sechage) = (int)(id(duree_sechage).state * 60);
+          id(temps_restant_sechage_sensor).publish_state(id(temps_restant_sechage));
       - while:
           condition:
             lambda: 'return id(temps_restant_sechage) > 0 && id(mode_fonctionnement).state == "Séchage approfondi";'
@@ -281,12 +297,15 @@ script:
             - delay: 60s
             - lambda: |-
                 id(temps_restant_sechage) -= 1;
+                id(temps_restant_sechage_sensor).publish_state(id(temps_restant_sechage));
                 ESP_LOGD("timer_sechage", "Temps restant %d min", id(temps_restant_sechage));
                 if (id(ecran_oled) != nullptr) { id(ecran_oled).update(); }
       - lambda: |-
           if (id(mode_fonctionnement).state == "Séchage approfondi") {
             id(mode_fonctionnement).publish_state("Maintien");
           }
+          id(temps_restant_sechage) = 0;
+          id(temps_restant_sechage_sensor).publish_state(0);
 
 font:
   - file: "gfonts://Roboto"


### PR DESCRIPTION
## Summary
- ensure the drying countdown sensor publishes its value on boot and is typed as a duration
- document the new sensor, highlighting it in the feature list and drying mode description
- update the Lovelace card example so the countdown appears in the Mushroom chips and grid

## Testing
- not run (documentation and configuration updates only)

------
https://chatgpt.com/codex/tasks/task_e_6905fa5ca3988330aaa62c47d05629cb