### PR TITLE
Ensure drying time sensor updates Home Assistant

### DIFF
--- a/enceinte_fil3d.yaml
+++ b/enceinte_fil3d.yaml
@@ -85,9 +85,18 @@ sensor:
     unit_of_measurement: "min"
     accuracy_decimals: 0
     device_class: duration
+    force_update: true
     icon: "mdi:clock-outline"
     lambda: 'return (float) id(temps_restant_sechage);'
     update_interval: never
+
+interval:
+  - interval: 30s
+    then:
+      - lambda: |-
+          if (id(temps_restant_sechage_sensor) != nullptr) {
+            id(temps_restant_sechage_sensor).publish_state(id(temps_restant_sechage));
+          }
 
 output:
   - platform: ledc


### PR DESCRIPTION
## Summary
- force the drying time template sensor to push state changes to Home Assistant
- add a periodic interval task that republishes the current countdown value so the entity stays in sync

## Testing
- Not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_690606e56d0483308144a6ac0bb162e6