### PR TITLE
Ensure drying countdown updates when using the mode button

### DIFF
--- a/enceinte_fil3d.yaml
+++ b/enceinte_fil3d.yaml
@@ -541,14 +541,24 @@ binary_sensor:
     on_press:
       then:
         - lambda: |-
+            std::string next_mode;
             if (id(mode_fonctionnement).state == "Off") {
-              id(mode_fonctionnement).publish_state("Test");
+              next_mode = "Test";
             } else if (id(mode_fonctionnement).state == "Test") {
-              id(mode_fonctionnement).publish_state("Maintien");
+              next_mode = "Maintien";
             } else if (id(mode_fonctionnement).state == "Maintien") {
-              id(mode_fonctionnement).publish_state("Séchage approfondi");
+              next_mode = "Séchage approfondi";
             } else {
-              id(mode_fonctionnement).publish_state("Off");
+              next_mode = "Off";
+            }
+            id(mode_fonctionnement).publish_state(next_mode);
+            if (next_mode == "Séchage approfondi") {
+              id(timer_sechage).execute();
+            } else {
+              id(temps_restant_sechage) = 0;
+              if (id(temps_restant_sechage_sensor) != nullptr) {
+                id(temps_restant_sechage_sensor).publish_state(0);
+              }
             }
         - script.execute: gestion_chauffage
         - lambda: |-


### PR DESCRIPTION
## Summary
- start the drying countdown script when the hardware mode button selects "Séchage approfondi"
- reset the remaining drying time sensor when leaving the drying mode via the button

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_69060e592780833094a6a4f8ca771a58